### PR TITLE
feat(doctrine): support backed enum for faceted properties

### DIFF
--- a/src/Adapter/Doctrine/DoctrineAdapter.php
+++ b/src/Adapter/Doctrine/DoctrineAdapter.php
@@ -93,10 +93,12 @@ readonly class DoctrineAdapter implements AdapterInterface
             $uncheckedFacets = [];
             $qb = $helper->getFacetTermQuery($facet);
             foreach ($qb->getQuery()->getArrayResult() as $row) {
-                if (\in_array($row['value'], $checkedValues)) {
-                    $checkedFacets[$row['value']] = $row['total'];
+                $rowValue = $row['value'] instanceof \BackedEnum ? $row['value']->value : $row['value'];
+
+                if (\in_array($rowValue, $checkedValues)) {
+                    $checkedFacets[$rowValue] = $row['total'];
                 } else {
-                    $uncheckedFacets[$row['value']] = $row['total'];
+                    $uncheckedFacets[$rowValue] = $row['total'];
                 }
             }
 

--- a/tests/Adapter/Doctrine/DoctrineAdapterTest.php
+++ b/tests/Adapter/Doctrine/DoctrineAdapterTest.php
@@ -16,6 +16,7 @@ namespace Mezcalito\UxSearchBundle\Tests\Adapter\Doctrine;
 use Mezcalito\UxSearchBundle\Search\Filter\RangeFilter;
 use Mezcalito\UxSearchBundle\Search\Filter\TermFilter;
 use Mezcalito\UxSearchBundle\Search\ResultSet\ResultSet;
+use Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\CategoryEnum;
 use Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo;
 
 class DoctrineAdapterTest extends AbstractDoctrineTestCase
@@ -53,14 +54,16 @@ class DoctrineAdapterTest extends AbstractDoctrineTestCase
     public function testSearchWithFilter(): void
     {
         $this->createDatabase([
-            new Foo('A', '1', 10),
-            new Foo('A', '1', 13),  // filtered
-            new Foo('B', '2', 12),  // filtered
-            new Foo('C', '2', 13),  // filtered
+            new Foo('A', '1', 10, CategoryEnum::PHARMACY),
+            new Foo('A', '1', 13, CategoryEnum::PHARMACY),  // filtered
+            new Foo('B', '2', 12, CategoryEnum::PHARMACY),  // filtered
+            new Foo('C', '2', 13, CategoryEnum::PHARMACY),  // filtered
+            new Foo('D', '2', 25, CategoryEnum::GRILL), // filtered
         ]);
 
         $this->query->addActiveFilter(new RangeFilter('o.price', 10, 12));
         $this->query->addActiveFilter(new TermFilter('o.type', ['A']));
+        $this->query->addActiveFilter(new TermFilter('o.category', [CategoryEnum::PHARMACY]));
 
         $resultSet = $this->adapter->search($this->query, $this->search);
 

--- a/tests/Fixtures/Adapter/Doctrine/CategoryEnum.php
+++ b/tests/Fixtures/Adapter/Doctrine/CategoryEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the UxSearch project.
+ *
+ * (c) Mezcalito (https://www.mezcalito.fr)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine;
+
+enum CategoryEnum: string
+{
+    case GRILL = 'grill';
+    case PHARMACY = 'pharmacy';
+}

--- a/tests/Fixtures/Adapter/Doctrine/Foo.php
+++ b/tests/Fixtures/Adapter/Doctrine/Foo.php
@@ -27,6 +27,7 @@ class Foo
         #[ORM\Column] public ?string $type = null,
         #[ORM\Column] public ?string $brand = null,
         #[ORM\Column] public ?float $price = null,
+        #[ORM\Column(nullable: true)] public ?CategoryEnum $category = null,
     ) {
     }
 }


### PR DESCRIPTION
When using the Doctrine adapter and having a property of type `enumType`, facetting on the property does not work.

This change checks if the property is of type `BackedEnum` and handles this case.