### PR TITLE
feat: Manage sub-entity facet

### DIFF
--- a/src/Adapter/Doctrine/QueryBuilderHelper.php
+++ b/src/Adapter/Doctrine/QueryBuilderHelper.php
@@ -64,10 +64,14 @@ readonly class QueryBuilderHelper
     public function getFacetTermQuery(Facet $facet): QueryBuilder
     {
         $qb = $this->createBaseQueryBuilder();
+
+        [$alias, $property] = $this->extractAliasAndProperty($facet->getProperty());
+        $this->updateQueryBuilderAssociations($qb, $alias);
+
         $qb
-            ->select(\sprintf('%s as value, count(%s) AS total', $facet->getProperty(), $facet->getProperty()))
+            ->select(\sprintf('%s.%s as value, count(%s.%s) AS total', $alias, $property, $alias, $property))
             ->orderBy('total', 'desc')
-            ->groupBy($facet->getProperty())
+            ->groupBy(\sprintf('%s.%s', $alias, $property))
             ->setMaxResults($this->search->getResolvedAdapterParameter(DoctrineAdapter::MAX_FACET_VALUES_PARAM));
 
         $this->applyQueryString($qb);
@@ -86,8 +90,12 @@ readonly class QueryBuilderHelper
     public function getFacetStatsQuery(mixed $facet): QueryBuilder
     {
         $qb = $this->createBaseQueryBuilder();
+
+        [$alias, $property] = $this->extractAliasAndProperty($facet->getProperty());
+        $this->updateQueryBuilderAssociations($qb, $alias);
+
         $qb
-            ->select(\sprintf('min(%s) as min, max(%s) AS max', $facet->getProperty(), $facet->getProperty()));
+            ->select(\sprintf('min(%s.%s) as min, max(%s.%s) AS max', $alias, $property, $alias, $property));
 
         $this->applyQueryString($qb);
 
@@ -113,6 +121,27 @@ readonly class QueryBuilderHelper
         return $qb;
     }
 
+    private function extractAliasAndProperty(string $property): array
+    {
+        if (str_contains($property, '.')) {
+            return explode('.', $property);
+        }
+
+        return ['o', $property];
+    }
+
+    private function updateQueryBuilderAssociations(QueryBuilder $qb, string $alias): void
+    {
+        if ('o' === $alias) {
+            return;
+        }
+
+        $metadata = $this->manager->getClassMetadata($this->search->getIndexName());
+        if (\array_key_exists($alias, $metadata->associationMappings) && !\in_array($alias, $qb->getAllAliases(), true)) {
+            $qb->leftJoin('o.'.$alias, $alias);
+        }
+    }
+
     private function getIdentifierField(): string
     {
         $metadata = $this->manager->getClassMetadata($this->search->getIndexName());
@@ -125,22 +154,25 @@ readonly class QueryBuilderHelper
 
     private function applyFilter(QueryBuilder $qb, FilterInterface $filter)
     {
-        if ($filter instanceof TermFilter && $filter->hasValues()) {
-            $parameterName = u(\sprintf('%s_terms', $filter->getProperty()))->snake()->toString();
+        [$alias, $property] = $this->extractAliasAndProperty($filter->getProperty());
+        $this->updateQueryBuilderAssociations($qb, $alias);
 
-            $qb->andWhere(\sprintf('%s in (:%s)', $filter->getProperty(), $parameterName));
+        if ($filter instanceof TermFilter && $filter->hasValues()) {
+            $parameterName = u(\sprintf('%s_%s_terms', $alias, $property))->snake()->toString();
+
+            $qb->andWhere(\sprintf('%s.%s in (:%s)', $alias, $property, $parameterName));
             $qb->setParameter($parameterName, array_values($filter->getValues()));
         }
 
         if ($filter instanceof RangeFilter && $filter->getMax()) {
-            $parameterName = u(\sprintf('%s_max', $filter->getProperty()))->snake()->toString();
-            $qb->andWhere(\sprintf('%s <= :%s ', $filter->getProperty(), $parameterName));
+            $parameterName = u(\sprintf('%s_%s_max', $alias, $property))->snake()->toString();
+            $qb->andWhere(\sprintf('%s.%s <= :%s ', $alias, $property, $parameterName));
             $qb->setParameter($parameterName, $filter->getMax());
         }
 
         if ($filter instanceof RangeFilter && $filter->getMin()) {
-            $parameterName = u(\sprintf('%s_min', $filter->getProperty()))->snake()->toString();
-            $qb->andWhere(\sprintf('%s >= :%s', $filter->getProperty(), $parameterName));
+            $parameterName = u(\sprintf('%s_%s_min', $alias, $property))->snake()->toString();
+            $qb->andWhere(\sprintf('%s.%s >= :%s', $alias, $property, $parameterName));
             $qb->setParameter($parameterName, $filter->getMin());
         }
     }

--- a/tests/Adapter/Doctrine/AbstractDoctrineTestCase.php
+++ b/tests/Adapter/Doctrine/AbstractDoctrineTestCase.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Mezcalito\UxSearchBundle\Adapter\Doctrine\DoctrineAdapter;
 use Mezcalito\UxSearchBundle\Search\Query;
 use Mezcalito\UxSearchBundle\Search\SearchInterface;
+use Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Bar;
 use Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo;
 use Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\FooSearch;
 use PHPUnit\Framework\TestCase;
@@ -68,8 +69,10 @@ abstract class AbstractDoctrineTestCase extends TestCase
     protected function createDatabase(array $data = []): void
     {
         $schemaTool = new SchemaTool($this->entityManager);
-        $class = $this->entityManager->getClassMetadata(Foo::class);
-        $schemaTool->createSchema([$class]);
+        $schemaTool->createSchema([
+            $this->entityManager->getClassMetadata(Foo::class),
+            $this->entityManager->getClassMetadata(Bar::class),
+        ]);
 
         foreach ($data as $foo) {
             $this->entityManager->persist($foo);

--- a/tests/Adapter/Doctrine/QueryBuilderHelperTest.php
+++ b/tests/Adapter/Doctrine/QueryBuilderHelperTest.php
@@ -37,7 +37,7 @@ class QueryBuilderHelperTest extends AbstractDoctrineTestCase
 
     public function testTotalResultsWithFilterQuery()
     {
-        $this->query->addActiveFilter(new TermFilter('o.brand', ['A', 'B']));
+        $this->query->addActiveFilter(new TermFilter('brand', ['A', 'B']));
         $qb = $this->helper->getTotalResultsQuery();
 
         $dql = $qb->getQuery()->getDQL();
@@ -69,7 +69,7 @@ class QueryBuilderHelperTest extends AbstractDoctrineTestCase
 
     public function testResultsQueryWithFilter()
     {
-        $this->query->addActiveFilter(new RangeFilter('o.price', 10, 100));
+        $this->query->addActiveFilter(new RangeFilter('price', 10, 100));
         $dql = $this->helper->getResultsQuery()->getQuery()->getDQL();
 
         $this->assertEquals('SELECT o FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.price <= :o_price_max  AND o.price >= :o_price_min ORDER BY o.price asc', $dql);
@@ -77,21 +77,30 @@ class QueryBuilderHelperTest extends AbstractDoctrineTestCase
 
     public function testFacetTermQuery()
     {
-        $this->query->addActiveFilter(new TermFilter('o.brand', ['A', 'B']));
-        $this->query->addActiveFilter(new RangeFilter('o.price', 10, 100));
+        $this->query->addActiveFilter(new TermFilter('brand', ['A', 'B']));
+        $this->query->addActiveFilter(new RangeFilter('price', 10, 100));
 
         $dql = $this->helper->getFacetTermQuery($this->search->getFacet('o.brand'))->getQuery()->getDQL();
 
-        $this->assertEquals('SELECT o.brand as value, count(o.brand) AS total FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.price <= :o_price_max  AND o.price >= :o_price_min GROUP BY o.brand ORDER BY total desc', $dql);
+        $this->assertEquals('SELECT o.brand as value, count(o.brand) AS total FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.brand in (:o_brand_terms) AND o.price <= :o_price_max  AND o.price >= :o_price_min GROUP BY o.brand ORDER BY total desc', $dql);
     }
 
     public function testFacetStatsQuery()
     {
-        $this->query->addActiveFilter(new TermFilter('o.brand', ['A', 'B']));
-        $this->query->addActiveFilter(new RangeFilter('o.price', 10, 100));
+        $this->query->addActiveFilter(new TermFilter('brand', ['A', 'B']));
+        $this->query->addActiveFilter(new RangeFilter('price', 10, 100));
 
         $dql = $this->helper->getFacetStatsQuery($this->search->getFacet('o.price'))->getQuery()->getDQL();
 
-        $this->assertEquals('SELECT min(o.price) as min, max(o.price) AS max FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.brand in (:o_brand_terms)', $dql);
+        $this->assertEquals('SELECT min(o.price) as min, max(o.price) AS max FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.brand in (:o_brand_terms) AND o.price <= :o_price_max  AND o.price >= :o_price_min', $dql);
+    }
+
+    public function testFacetTermSubEntityQuery()
+    {
+        $this->query->addActiveFilter(new TermFilter('bar.name', ['A']));
+
+        $dql = $this->helper->getFacetTermQuery($this->search->getFacet('bar.name'))->getQuery()->getDQL();
+
+        $this->assertEquals('SELECT bar.name as value, count(bar.name) AS total FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o LEFT JOIN o.bar bar GROUP BY bar.name ORDER BY total desc', $dql);
     }
 }

--- a/tests/Fixtures/Adapter/Doctrine/Bar.php
+++ b/tests/Fixtures/Adapter/Doctrine/Bar.php
@@ -16,7 +16,7 @@ namespace Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-class Foo
+class Bar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -24,11 +24,7 @@ class Foo
     public ?int $id = null;
 
     public function __construct(
-        #[ORM\Column] public ?string $type = null,
-        #[ORM\Column] public ?string $brand = null,
-        #[ORM\Column] public ?float $price = null,
-        #[ORM\Column(nullable: true)] public ?CategoryEnum $category = null,
-        #[ORM\ManyToOne] #[ORM\JoinColumn(nullable: true)] public ?Bar $bar = null,
+        #[ORM\Column] public ?string $name = null,
     ) {
     }
 }

--- a/tests/Fixtures/Adapter/Doctrine/FooSearch.php
+++ b/tests/Fixtures/Adapter/Doctrine/FooSearch.php
@@ -26,6 +26,7 @@ class FooSearch extends AbstractSearch
             ->addFacet('o.type', 'Type')
             ->addFacet('o.brand', 'Brand')
             ->addFacet('o.price', 'Price', RangeInput::class)
+            ->addFacet('bar.name', 'Name')
             ->addAvailableSort('o.price:asc', 'Price ↑')
             ->addAvailableSort('o.price:desc', 'Price ↓')
         ;


### PR DESCRIPTION
The purpose of this PR is to enable sub-entity facets in search configuration, like this:

```php
public function build(array $options = []): void
{
    $this
        ->addFacet('genres', 'Genre', null, ['limit' => 10])
        ->addFacet('director. fullname', 'Director')
    ;
}
```

It also solves a problem with the Doctrine adapter, which required facet properties to be prefixed with `o.` in order to be linked to the main entity whose alias was hard-coded in the querybuilders.