### PR TITLE
fix typo in word 'searchs' to 'searches'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Feel free to check the documentation to [customize your search](docs/usage/custo
 
 To render a search in your Twig template, you can use the `Mezcalito:UxSearch:Layout`, you will then have a default rendering provided by the bundle.
 
-### Using compnent function
+### Using component function
 ```twig
 {{ component('Mezcalito:UxSearch:Layout', { name: 'listing' }) }}
 ```

--- a/src/DependencyInjection/RegisterSearchPass.php
+++ b/src/DependencyInjection/RegisterSearchPass.php
@@ -34,7 +34,7 @@ class RegisterSearchPass implements CompilerPassInterface
 
         $container
             ->getDefinition(SearchProvider::class)
-            ->setArgument('$searchs', new IteratorArgument($listSearchTypes))
+            ->setArgument('$searches', new IteratorArgument($listSearchTypes))
         ;
     }
 }

--- a/src/Search/SearchProvider.php
+++ b/src/Search/SearchProvider.php
@@ -18,14 +18,14 @@ use Mezcalito\UxSearchBundle\Exception\SearchException;
 readonly class SearchProvider
 {
     public function __construct(
-        private iterable $searchs,
+        private iterable $searches,
     ) {
     }
 
     public function getSearch(string $name): SearchInterface
     {
         /** @var SearchInterface $search */
-        foreach ($this->searchs as $searchName => $search) {
+        foreach ($this->searches as $searchName => $search) {
             if ($name === $searchName) {
                 return $search;
             }

--- a/tests/DependencyInjection/RegisterSearchPassTest.php
+++ b/tests/DependencyInjection/RegisterSearchPassTest.php
@@ -45,7 +45,7 @@ class RegisterSearchPassTest extends TestCase
 
         $updatedDefinition = $container->getDefinition(SearchProvider::class);
 
-        $iteratorArgument = $updatedDefinition->getArgument('$searchs');
+        $iteratorArgument = $updatedDefinition->getArgument('$searches');
         $this->assertInstanceOf(IteratorArgument::class, $iteratorArgument);
 
         $arguments = $iteratorArgument->getValues();
@@ -69,7 +69,7 @@ class RegisterSearchPassTest extends TestCase
 
         $updatedDefinition = $container->getDefinition(SearchProvider::class);
 
-        $argument = $updatedDefinition->getArgument('$searchs');
+        $argument = $updatedDefinition->getArgument('$searches');
         $this->assertInstanceOf(IteratorArgument::class, $argument);
         $this->assertEmpty($argument->getValues());
     }


### PR DESCRIPTION
Tiny issue, but not a public property and all tests pass when I fix it.