### PR TITLE
fix: preserve url query parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "symfony/maker-bundle": "^1.62",
     "symfony/runtime": "^6.4|^7.0",
     "symfony/translation": "^7.2",
+    "symfony/var-exporter": "^6.4|^7.0",
     "symfony/web-profiler-bundle": "^6.4|^7.0"
   },
   "suggest": {

--- a/src/Twig/Components/Layout.php
+++ b/src/Twig/Components/Layout.php
@@ -51,7 +51,6 @@ class Layout
 
     public ?SearchInterface $search = null;
 
-    #[LiveProp(useSerializerForHydration: true)]
     public ?CurrentRequest $currentRequest = null;
 
     public function __construct(
@@ -80,6 +79,12 @@ class Layout
     public function onReRender(): void
     {
         $this->search = $this->getSearch($this->name)->create($this->options);
+        $this->currentRequest = CurrentRequest::fromRequest($this->requestStack->getMainRequest());
+
+        if ($this->search->hasUrlRewriting()) {
+            $this->getUrlFormater()->applyFilters($this->currentRequest, $this->search, $this->query);
+        }
+
         $this->searcher->search($this->query, $this->search);
 
         if ($this->search->hasUrlRewriting()) {


### PR DESCRIPTION
Fixes #25 

This is the change outlined in the linked issue. I'll use to opportunity to come up with a possible e2e test setup with Playwright to also test the js parts of the bundle.