### PR TITLE
Add dev dependency symfony/var-exporter for lazy loading w/ PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "symfony/maker-bundle": "^1.62",
     "symfony/runtime": "^6.4|^7.0",
     "symfony/translation": "^7.2",
+    "symfony/var-exporter": "^6.4|^7.0",
     "symfony/web-profiler-bundle": "^6.4|^7.0"
   },
   "suggest": {


### PR DESCRIPTION
This solves the test failures with PHP 8.4