### PR TITLE
fix: Reset available sorts and facets between each FrankenPHP request

### DIFF
--- a/src/MezcalitoUxSearchBundle.php
+++ b/src/MezcalitoUxSearchBundle.php
@@ -71,6 +71,7 @@ class MezcalitoUxSearchBundle extends AbstractBundle
             }
 
             $definition->addTag('mezcalito_ux_search.search', $tagAttributes);
+            $definition->addTag('kernel.reset', ['method' => 'reset']);
         });
 
         $builder->registerForAutoconfiguration(AdapterFactoryInterface::class)->addTag('mezcalito_ux_search.adapter_factory');

--- a/src/Search/AbstractSearch.php
+++ b/src/Search/AbstractSearch.php
@@ -18,8 +18,9 @@ use Mezcalito\UxSearchBundle\Exception\SearchException;
 use Mezcalito\UxSearchBundle\Search\Url\DefaultUrlFormater;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
-abstract class AbstractSearch implements SearchInterface
+abstract class AbstractSearch implements SearchInterface, ResetInterface
 {
     /** @var int[] */
     private array $availableHitsPerPage = [12];
@@ -204,5 +205,13 @@ abstract class AbstractSearch implements SearchInterface
         $this->urlFormater = $urlFormater;
 
         return $this;
+    }
+
+    public function reset(): void
+    {
+        unset($this->availableSorts, $this->facets);
+
+        $this->availableSorts = [];
+        $this->facets = [];
     }
 }


### PR DESCRIPTION
When using FrankenPHP's worker mode, the Symfony container is not reset, which means that the available sorts and facets are retained between each request and new ones are added on top.

The solution is to call an event (`kernel.reset`) that is called at the end of each request, event when using the worker mode to reset some variables to their initial state, ready for the next request.