### PR TITLE
Handle float values in query builders

### DIFF
--- a/src/Adapter/Algolia/QueryBuilder.php
+++ b/src/Adapter/Algolia/QueryBuilder.php
@@ -94,11 +94,11 @@ class QueryBuilder
                     break;
                 case RangeFilter::class:
                     if (null !== $filter->getMin()) {
-                        $formated[] = \sprintf('%s >= %d', $filter->getProperty(), $filter->getMin());
+                        $formated[] = \sprintf('%s >= %s', $filter->getProperty(), $filter->getMin());
                     }
 
                     if (null !== $filter->getMax()) {
-                        $formated[] = \sprintf('%s <= %d', $filter->getProperty(), $filter->getMax());
+                        $formated[] = \sprintf('%s <= %s', $filter->getProperty(), $filter->getMax());
                     }
 
                     break;

--- a/src/Adapter/Meilisearch/QueryBuilder.php
+++ b/src/Adapter/Meilisearch/QueryBuilder.php
@@ -105,11 +105,11 @@ class QueryBuilder
                     break;
                 case RangeFilter::class:
                     if (null !== $filter->getMin()) {
-                        $formated[] = \sprintf('%s >= %d', $filter->getProperty(), $filter->getMin());
+                        $formated[] = \sprintf('%s >= %s', $filter->getProperty(), $filter->getMin());
                     }
 
                     if (null !== $filter->getMax()) {
-                        $formated[] = \sprintf('%s <= %d', $filter->getProperty(), $filter->getMax());
+                        $formated[] = \sprintf('%s <= %s', $filter->getProperty(), $filter->getMax());
                     }
 
                     break;

--- a/tests/Adapter/Algolia/QueryBuilderTest.php
+++ b/tests/Adapter/Algolia/QueryBuilderTest.php
@@ -87,6 +87,34 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals('products', $result['requests'][0]['indexName']);
     }
 
+    public function testBuildWithFloatRangeFilter(): void
+    {
+        $query = $this->createMock(Query::class);
+        $search = $this->createMock(SearchInterface::class);
+
+        $query->method('getActiveFilters')->willReturn([
+            new RangeFilter('price', 19.99, 99.95),
+        ]);
+
+        $query->method('getActiveHitsPerPage')->willReturn(10);
+        $query->method('getCurrentPage')->willReturn(1);
+        $query->method('getQueryString')->willReturn('');
+
+        $search->method('getIndexName')->willReturn('products');
+        $search->method('getFacets')->willReturn([
+            new RangeFilter('price', null, null),
+        ]);
+        $search->method('getResolvedAdapterParameters')->willReturn([]);
+
+        $queryBuilder = new QueryBuilder();
+
+        $result = $queryBuilder->build($query, $search);
+
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('price >= 19.99', $result['requests'][0]['filters']);
+        $this->assertStringContainsString('price <= 99.95', $result['requests'][0]['filters']);
+    }
+
     public function testBuildWithZeroValueRangeFilter(): void
     {
         $query = $this->createMock(Query::class);

--- a/tests/Adapter/Meilisearch/QueryBuilderTest.php
+++ b/tests/Adapter/Meilisearch/QueryBuilderTest.php
@@ -241,6 +241,46 @@ class QueryBuilderTest extends TestCase
         ], $priceFacetQuery->toArray());
     }
 
+    public function testFloatRangeFilter(): void
+    {
+        $this->search->method('getFacets')->willReturn([
+            new Facet('price', 'Price'),
+        ]);
+
+        $query = (new Query())
+            ->addActiveFilter(new RangeFilter('price', 19.99, 99.95))
+        ;
+
+        $searchQueries = $this->queryBuilder->build($query, $this->search);
+
+        $this->assertCount(2, $searchQueries);
+
+        $mainSearchQuery = $searchQueries[0];
+
+        $this->assertInstanceOf(SearchQuery::class, $mainSearchQuery);
+        $this->assertEquals([
+            'indexUid' => 'test',
+            'filter' => [
+                'price >= 19.99',
+                'price <= 99.95',
+            ],
+            'q' => '',
+            'sort' => [],
+            'hitsPerPage' => 12,
+            'page' => 1,
+            'attributesToRetrieve' => ['*'],
+            'attributesToCrop' => [],
+            'cropLength' => 10,
+            'cropMarker' => '...',
+            'attributesToHighlight' => [],
+            'highlightPreTag' => '<em>',
+            'highlightPostTag' => '</em>',
+            'showRankingScore' => true,
+            'facets' => ['price'],
+            'distinct' => 'product_id',
+        ], $mainSearchQuery->toArray());
+    }
+
     public function testZeroValueRangeFilter(): void
     {
         $this->search->method('getFacets')->willReturn([


### PR DESCRIPTION
Float values were converted into integers on query builders for Algolia and Meilisearch.
Using `%s` instead of `%f` to keep exact value and prevent unnecessary trailing zeros.