### PR TITLE
Handle zero values correctly in RangeFilter

### DIFF
--- a/src/Adapter/Algolia/QueryBuilder.php
+++ b/src/Adapter/Algolia/QueryBuilder.php
@@ -93,11 +93,11 @@ class QueryBuilder
                     $formated[] = implode(' OR ', $or);
                     break;
                 case RangeFilter::class:
-                    if ($filter->getMin()) {
+                    if (null !== $filter->getMin()) {
                         $formated[] = \sprintf('%s >= %d', $filter->getProperty(), $filter->getMin());
                     }
 
-                    if ($filter->getMax()) {
+                    if (null !== $filter->getMax()) {
                         $formated[] = \sprintf('%s <= %d', $filter->getProperty(), $filter->getMax());
                     }
 

--- a/src/Adapter/Doctrine/QueryBuilderHelper.php
+++ b/src/Adapter/Doctrine/QueryBuilderHelper.php
@@ -164,13 +164,13 @@ readonly class QueryBuilderHelper
             $qb->setParameter($parameterName, array_values($filter->getValues()));
         }
 
-        if ($filter instanceof RangeFilter && $filter->getMax()) {
+        if ($filter instanceof RangeFilter && null !== $filter->getMax()) {
             $parameterName = u(\sprintf('%s_%s_max', $alias, $property))->snake()->toString();
             $qb->andWhere(\sprintf('%s.%s <= :%s ', $alias, $property, $parameterName));
             $qb->setParameter($parameterName, $filter->getMax());
         }
 
-        if ($filter instanceof RangeFilter && $filter->getMin()) {
+        if ($filter instanceof RangeFilter && null !== $filter->getMin()) {
             $parameterName = u(\sprintf('%s_%s_min', $alias, $property))->snake()->toString();
             $qb->andWhere(\sprintf('%s.%s >= :%s', $alias, $property, $parameterName));
             $qb->setParameter($parameterName, $filter->getMin());

--- a/src/Adapter/Meilisearch/QueryBuilder.php
+++ b/src/Adapter/Meilisearch/QueryBuilder.php
@@ -104,11 +104,11 @@ class QueryBuilder
                     $formated[] = $or;
                     break;
                 case RangeFilter::class:
-                    if ($filter->getMin()) {
+                    if (null !== $filter->getMin()) {
                         $formated[] = \sprintf('%s >= %d', $filter->getProperty(), $filter->getMin());
                     }
 
-                    if ($filter->getMax()) {
+                    if (null !== $filter->getMax()) {
                         $formated[] = \sprintf('%s <= %d', $filter->getProperty(), $filter->getMax());
                     }
 

--- a/src/Search/Filter/RangeFilter.php
+++ b/src/Search/Filter/RangeFilter.php
@@ -49,6 +49,6 @@ class RangeFilter extends AbstractFilter
 
     public function hasValues(): bool
     {
-        return $this->min || $this->max;
+        return null !== $this->min || null !== $this->max;
     }
 }

--- a/tests/Adapter/Algolia/QueryBuilderTest.php
+++ b/tests/Adapter/Algolia/QueryBuilderTest.php
@@ -86,4 +86,60 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertEquals('products', $result['requests'][0]['indexName']);
     }
+
+    public function testBuildWithZeroValueRangeFilter(): void
+    {
+        $query = $this->createMock(Query::class);
+        $search = $this->createMock(SearchInterface::class);
+
+        $query->method('getActiveFilters')->willReturn([
+            new RangeFilter('stock', 0, 100),
+        ]);
+
+        $query->method('getActiveHitsPerPage')->willReturn(10);
+        $query->method('getCurrentPage')->willReturn(1);
+        $query->method('getQueryString')->willReturn('');
+
+        $search->method('getIndexName')->willReturn('products');
+        $search->method('getFacets')->willReturn([
+            new RangeFilter('stock', null, null),
+        ]);
+        $search->method('getResolvedAdapterParameters')->willReturn([]);
+
+        $queryBuilder = new QueryBuilder();
+
+        $result = $queryBuilder->build($query, $search);
+
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('stock >= 0', $result['requests'][0]['filters']);
+        $this->assertStringContainsString('stock <= 100', $result['requests'][0]['filters']);
+    }
+
+    public function testBuildWithZeroMaxValueRangeFilter(): void
+    {
+        $query = $this->createMock(Query::class);
+        $search = $this->createMock(SearchInterface::class);
+
+        $query->method('getActiveFilters')->willReturn([
+            new RangeFilter('discount', -10, 0),
+        ]);
+
+        $query->method('getActiveHitsPerPage')->willReturn(10);
+        $query->method('getCurrentPage')->willReturn(1);
+        $query->method('getQueryString')->willReturn('');
+
+        $search->method('getIndexName')->willReturn('products');
+        $search->method('getFacets')->willReturn([
+            new RangeFilter('discount', null, null),
+        ]);
+        $search->method('getResolvedAdapterParameters')->willReturn([]);
+
+        $queryBuilder = new QueryBuilder();
+
+        $result = $queryBuilder->build($query, $search);
+
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('discount >= -10', $result['requests'][0]['filters']);
+        $this->assertStringContainsString('discount <= 0', $result['requests'][0]['filters']);
+    }
 }

--- a/tests/Adapter/Doctrine/QueryBuilderHelperTest.php
+++ b/tests/Adapter/Doctrine/QueryBuilderHelperTest.php
@@ -130,4 +130,26 @@ class QueryBuilderHelperTest extends AbstractDoctrineTestCase
 
         $this->assertEquals('SELECT o FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o ORDER BY o.price desc', $dql);
     }
+
+    public function testResultsQueryWithZeroMinValueRangeFilter()
+    {
+        $this->query->addActiveFilter(new RangeFilter('price', 0, 100));
+        $qb = $this->helper->getResultsQuery();
+        $dql = $qb->getQuery()->getDQL();
+
+        $this->assertEquals('SELECT o FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.price <= :o_price_max  AND o.price >= :o_price_min ORDER BY o.price asc', $dql);
+        $this->assertEquals(0, $qb->getParameter('o_price_min')->getValue());
+        $this->assertEquals(100, $qb->getParameter('o_price_max')->getValue());
+    }
+
+    public function testResultsQueryWithZeroMaxValueRangeFilter()
+    {
+        $this->query->addActiveFilter(new RangeFilter('price', -10, 0));
+        $qb = $this->helper->getResultsQuery();
+        $dql = $qb->getQuery()->getDQL();
+
+        $this->assertEquals('SELECT o FROM Mezcalito\UxSearchBundle\Tests\Fixtures\Adapter\Doctrine\Foo o WHERE o.price <= :o_price_max  AND o.price >= :o_price_min ORDER BY o.price asc', $dql);
+        $this->assertEquals(-10, $qb->getParameter('o_price_min')->getValue());
+        $this->assertEquals(0, $qb->getParameter('o_price_max')->getValue());
+    }
 }

--- a/tests/Adapter/Meilisearch/QueryBuilderTest.php
+++ b/tests/Adapter/Meilisearch/QueryBuilderTest.php
@@ -240,4 +240,84 @@ class QueryBuilderTest extends TestCase
             'limit' => 0,
         ], $priceFacetQuery->toArray());
     }
+
+    public function testZeroValueRangeFilter(): void
+    {
+        $this->search->method('getFacets')->willReturn([
+            new Facet('stock', 'Stock'),
+        ]);
+
+        $query = (new Query())
+            ->addActiveFilter(new RangeFilter('stock', 0, 100))
+        ;
+
+        $searchQueries = $this->queryBuilder->build($query, $this->search);
+
+        $this->assertCount(2, $searchQueries);
+
+        $mainSearchQuery = $searchQueries[0];
+
+        $this->assertInstanceOf(SearchQuery::class, $mainSearchQuery);
+        $this->assertEquals([
+            'indexUid' => 'test',
+            'filter' => [
+                'stock >= 0',
+                'stock <= 100',
+            ],
+            'q' => '',
+            'sort' => [],
+            'hitsPerPage' => 12,
+            'page' => 1,
+            'attributesToRetrieve' => ['*'],
+            'attributesToCrop' => [],
+            'cropLength' => 10,
+            'cropMarker' => '...',
+            'attributesToHighlight' => [],
+            'highlightPreTag' => '<em>',
+            'highlightPostTag' => '</em>',
+            'showRankingScore' => true,
+            'facets' => ['stock'],
+            'distinct' => 'product_id',
+        ], $mainSearchQuery->toArray());
+    }
+
+    public function testZeroMaxValueRangeFilter(): void
+    {
+        $this->search->method('getFacets')->willReturn([
+            new Facet('discount', 'Discount'),
+        ]);
+
+        $query = (new Query())
+            ->addActiveFilter(new RangeFilter('discount', -10, 0))
+        ;
+
+        $searchQueries = $this->queryBuilder->build($query, $this->search);
+
+        $this->assertCount(2, $searchQueries);
+
+        $mainSearchQuery = $searchQueries[0];
+
+        $this->assertInstanceOf(SearchQuery::class, $mainSearchQuery);
+        $this->assertEquals([
+            'indexUid' => 'test',
+            'filter' => [
+                'discount >= -10',
+                'discount <= 0',
+            ],
+            'q' => '',
+            'sort' => [],
+            'hitsPerPage' => 12,
+            'page' => 1,
+            'attributesToRetrieve' => ['*'],
+            'attributesToCrop' => [],
+            'cropLength' => 10,
+            'cropMarker' => '...',
+            'attributesToHighlight' => [],
+            'highlightPreTag' => '<em>',
+            'highlightPostTag' => '</em>',
+            'showRankingScore' => true,
+            'facets' => ['discount'],
+            'distinct' => 'product_id',
+        ], $mainSearchQuery->toArray());
+    }
 }

--- a/tests/Search/Filter/RangeFilterTest.php
+++ b/tests/Search/Filter/RangeFilterTest.php
@@ -70,4 +70,25 @@ class RangeFilterTest extends TestCase
 
         $this->assertTrue($filter->hasValues());
     }
+
+    public function testHasValuesWhenMinIsZero(): void
+    {
+        $filter = new RangeFilter('price', 0, 100);
+
+        $this->assertTrue($filter->hasValues());
+    }
+
+    public function testHasValuesWhenMaxIsZero(): void
+    {
+        $filter = new RangeFilter('price', -10, 0);
+
+        $this->assertTrue($filter->hasValues());
+    }
+
+    public function testHasValuesWhenBothAreZero(): void
+    {
+        $filter = new RangeFilter('price', 0, 0);
+
+        $this->assertTrue($filter->hasValues());
+    }
 }


### PR DESCRIPTION
Fix RangeFilter to correctly handle zero values (0) as legitimate min/max bounds.
Previously, falsy checks would skip filters with zero values. Now uses strict null comparisons.