### PR TITLE
Range slider : handle single value scenario

### DIFF
--- a/assets/dist/controllers/range-slider_controller.d.ts
+++ b/assets/dist/controllers/range-slider_controller.d.ts
@@ -49,5 +49,8 @@ export default class extends Controller<HTMLElement> {
     protected updateLayout(mid: number, range: number, min: number, max: number, thumbWidthVariable: string): void;
     protected updateGradients(mid: number, min: number, max: number, minValue: number, maxValue: number, thumbWidth: number, thumbWidthUnit: string): void;
     protected updateDisplayedValues(): void;
+    protected handleSingleValue(thumbWidthVariable: string): void;
+    protected enableInputs(): void;
+    protected disableInputs(): void;
     submit(): void;
 }

--- a/assets/dist/controllers/range-slider_controller.d.ts
+++ b/assets/dist/controllers/range-slider_controller.d.ts
@@ -34,5 +34,20 @@ export default class extends Controller<HTMLElement> {
     updateFloor: () => void;
     updateCeil: () => void;
     update(method?: 'floor' | 'ceil'): void;
+    protected getSliderValues(): {
+        min: number;
+        max: number;
+        step: number;
+        minValue: number;
+        maxValue: number;
+    };
+    protected getThumbWidthVariable(): string;
+    protected calculatePositions(values: ReturnType<typeof this.getSliderValues>, method: 'floor' | 'ceil'): {
+        mid: number;
+        range: number;
+    };
+    protected updateLayout(mid: number, range: number, min: number, max: number, thumbWidthVariable: string): void;
+    protected updateGradients(mid: number, min: number, max: number, minValue: number, maxValue: number, thumbWidth: number, thumbWidthUnit: string): void;
+    protected updateDisplayedValues(): void;
     submit(): void;
 }

--- a/assets/dist/controllers/range-slider_controller.js
+++ b/assets/dist/controllers/range-slider_controller.js
@@ -32,6 +32,12 @@ class default_1 extends Controller {
         const thumbWidthVariable = this.getThumbWidthVariable();
         const thumbWidth = parseFloat(thumbWidthVariable);
         const thumbWidthUnit = thumbWidthVariable.replace(/^[\d.]+/, '');
+        if (min === max) {
+            this.handleSingleValue(thumbWidthVariable);
+            this.updateDisplayedValues();
+            return;
+        }
+        this.enableInputs();
         const { mid, range } = this.calculatePositions(values, method);
         this.updateLayout(mid, range, min, max, thumbWidthVariable);
         this.updateGradients(mid, min, max, values.minValue, values.maxValue, thumbWidth, thumbWidthUnit);
@@ -79,6 +85,21 @@ class default_1 extends Controller {
         if (this.hasMaxValueTarget) {
             this.maxValueTarget.innerHTML = `${this.leadingValue}${this.maxInputTarget.value}${this.trailingValue}`;
         }
+    }
+    handleSingleValue(thumbWidthVariable) {
+        this.minInputTarget.style.flexBasis = `calc(100% + ${thumbWidthVariable})`;
+        this.maxInputTarget.style.flexBasis = `calc(0% + ${thumbWidthVariable})`;
+        this.element.style.setProperty('--ux-search-range-slider-min-gradient-position', '0%');
+        this.element.style.setProperty('--ux-search-range-slider-max-gradient-position', '100%');
+        this.disableInputs();
+    }
+    enableInputs() {
+        this.minInputTarget.disabled = false;
+        this.maxInputTarget.disabled = false;
+    }
+    disableInputs() {
+        this.minInputTarget.disabled = true;
+        this.maxInputTarget.disabled = true;
     }
     submit() {
         this.formTarget.requestSubmit();

--- a/assets/dist/controllers/range-slider_controller.js
+++ b/assets/dist/controllers/range-slider_controller.js
@@ -27,29 +27,52 @@ class default_1 extends Controller {
     updateFloor = () => this.update('floor');
     updateCeil = () => this.update('ceil');
     update(method = 'ceil') {
-        const min = parseFloat(this.minInputTarget.min);
-        const max = parseFloat(this.maxInputTarget.max);
-        const step = parseFloat(this.minInputTarget.step);
-        const minValue = parseFloat(this.minInputTarget.value);
-        const maxValue = parseFloat(this.maxInputTarget.value);
+        const values = this.getSliderValues();
+        const { min, max } = values;
+        const thumbWidthVariable = this.getThumbWidthVariable();
+        const thumbWidth = parseFloat(thumbWidthVariable);
+        const thumbWidthUnit = thumbWidthVariable.replace(/^[\d.]+/, '');
+        const { mid, range } = this.calculatePositions(values, method);
+        this.updateLayout(mid, range, min, max, thumbWidthVariable);
+        this.updateGradients(mid, min, max, values.minValue, values.maxValue, thumbWidth, thumbWidthUnit);
+        this.updateDisplayedValues();
+    }
+    getSliderValues() {
+        return {
+            min: parseFloat(this.minInputTarget.min),
+            max: parseFloat(this.maxInputTarget.max),
+            step: parseFloat(this.minInputTarget.step),
+            minValue: parseFloat(this.minInputTarget.value),
+            maxValue: parseFloat(this.maxInputTarget.value),
+        };
+    }
+    getThumbWidthVariable() {
+        return getComputedStyle(this.minInputTarget).getPropertyValue('--ux-search-range-slider-thumb-width');
+    }
+    calculatePositions(values, method) {
+        const { min, max, step, minValue, maxValue } = values;
         const midValue = (maxValue - minValue) / 2;
         const mid = minValue + Math[method](midValue / step) * step;
         const range = max - min;
-        const thumbWidthVariable = getComputedStyle(this.minInputTarget).getPropertyValue('--ux-search-range-slider-thumb-width');
-        const thumbWidth = parseFloat(thumbWidthVariable);
-        const thumbWidthUnit = thumbWidthVariable.replace(/^[\d.]+/, '');
+        return { mid, range };
+    }
+    updateLayout(mid, range, min, max, thumbWidthVariable) {
         const leftWidth = ((mid - min) / range) * 100;
         const rightWidth = ((max - mid) / range) * 100;
         this.minInputTarget.style.flexBasis = `calc(${leftWidth}% + ${thumbWidthVariable})`;
         this.maxInputTarget.style.flexBasis = `calc(${rightWidth}% + ${thumbWidthVariable})`;
         this.minInputTarget.max = mid.toFixed(this.precisionValue);
         this.maxInputTarget.min = mid.toFixed(this.precisionValue);
+    }
+    updateGradients(mid, min, max, minValue, maxValue, thumbWidth, thumbWidthUnit) {
         const minFill = (minValue - min) / (mid - min) || 0;
         const maxFill = (maxValue - mid) / (max - mid) || 0;
         const minFillThumb = ((0.5 - minFill) * thumbWidth).toFixed(this.precisionValue);
         const maxFillThumb = ((0.5 - maxFill) * thumbWidth).toFixed(this.precisionValue);
         this.element.style.setProperty('--ux-search-range-slider-min-gradient-position', `calc(${(minFill * 100).toFixed(this.precisionValue)}% + ${minFillThumb}${thumbWidthUnit})`);
         this.element.style.setProperty('--ux-search-range-slider-max-gradient-position', `calc(${(maxFill * 100).toFixed(this.precisionValue)}% + ${maxFillThumb}${thumbWidthUnit})`);
+    }
+    updateDisplayedValues() {
         if (this.hasMinValueTarget) {
             this.minValueTarget.innerHTML = `${this.leadingValue}${this.minInputTarget.value}${this.trailingValue}`;
         }

--- a/assets/src/controllers/range-slider_controller.ts
+++ b/assets/src/controllers/range-slider_controller.ts
@@ -52,6 +52,16 @@ export default class extends Controller<HTMLElement> {
     const thumbWidth = parseFloat(thumbWidthVariable);
     const thumbWidthUnit = thumbWidthVariable.replace(/^[\d.]+/, '');
 
+    // Handle edge case: min === max (single value, no range)
+    if (min === max) {
+      this.handleSingleValue(thumbWidthVariable);
+      this.updateDisplayedValues();
+      return;
+    }
+
+    // Re-enable inputs if they were disabled
+    this.enableInputs();
+
     // Calculate positions
     const { mid, range } = this.calculatePositions(values, method);
 
@@ -134,6 +144,29 @@ export default class extends Controller<HTMLElement> {
     if (this.hasMaxValueTarget) {
       this.maxValueTarget.innerHTML = `${this.leadingValue}${this.maxInputTarget.value}${this.trailingValue}`;
     }
+  }
+
+  protected handleSingleValue(thumbWidthVariable: string) {
+    // Place handlers at edges
+    this.minInputTarget.style.flexBasis = `calc(100% + ${thumbWidthVariable})`;
+    this.maxInputTarget.style.flexBasis = `calc(0% + ${thumbWidthVariable})`;
+
+    // Fill gradient completely
+    this.element.style.setProperty('--ux-search-range-slider-min-gradient-position', '0%');
+    this.element.style.setProperty('--ux-search-range-slider-max-gradient-position', '100%');
+
+    // Disable inputs to prevent interaction
+    this.disableInputs();
+  }
+
+  protected enableInputs() {
+    this.minInputTarget.disabled = false;
+    this.maxInputTarget.disabled = false;
+  }
+
+  protected disableInputs() {
+    this.minInputTarget.disabled = true;
+    this.maxInputTarget.disabled = true;
   }
 
   submit() {

--- a/assets/src/controllers/range-slider_controller.ts
+++ b/assets/src/controllers/range-slider_controller.ts
@@ -45,24 +45,53 @@ export default class extends Controller<HTMLElement> {
   updateCeil = (): void => this.update('ceil');
 
   update(method: 'floor' | 'ceil' = 'ceil') {
-    const min = parseFloat(this.minInputTarget.min);
-    const max = parseFloat(this.maxInputTarget.max);
-    const step = parseFloat(this.minInputTarget.step);
-    const minValue = parseFloat(this.minInputTarget.value);
-    const maxValue = parseFloat(this.maxInputTarget.value);
+    const values = this.getSliderValues();
+    const { min, max } = values;
 
+    const thumbWidthVariable = this.getThumbWidthVariable();
+    const thumbWidth = parseFloat(thumbWidthVariable);
+    const thumbWidthUnit = thumbWidthVariable.replace(/^[\d.]+/, '');
+
+    // Calculate positions
+    const { mid, range } = this.calculatePositions(values, method);
+
+    // Update layout
+    this.updateLayout(mid, range, min, max, thumbWidthVariable);
+
+    // Update gradients
+    this.updateGradients(mid, min, max, values.minValue, values.maxValue, thumbWidth, thumbWidthUnit);
+
+    // Update displayed values
+    this.updateDisplayedValues();
+  }
+
+  protected getSliderValues() {
+    return {
+      min: parseFloat(this.minInputTarget.min),
+      max: parseFloat(this.maxInputTarget.max),
+      step: parseFloat(this.minInputTarget.step),
+      minValue: parseFloat(this.minInputTarget.value),
+      maxValue: parseFloat(this.maxInputTarget.value),
+    };
+  }
+
+  protected getThumbWidthVariable(): string {
+    return getComputedStyle(this.minInputTarget).getPropertyValue('--ux-search-range-slider-thumb-width');
+  }
+
+  protected calculatePositions(
+    values: ReturnType<typeof this.getSliderValues>,
+    method: 'floor' | 'ceil',
+  ): { mid: number; range: number } {
+    const { min, max, step, minValue, maxValue } = values;
     const midValue = (maxValue - minValue) / 2;
     const mid = minValue + Math[method](midValue / step) * step;
-
     const range = max - min;
 
-    const thumbWidthVariable = getComputedStyle(this.minInputTarget).getPropertyValue(
-      '--ux-search-range-slider-thumb-width',
-    );
+    return { mid, range };
+  }
 
-    const thumbWidth = parseFloat(thumbWidthVariable);
-    const thumbWidthUnit = thumbWidthVariable.replace(/^[\d.]+/, ''); // px, em, rem...
-
+  protected updateLayout(mid: number, range: number, min: number, max: number, thumbWidthVariable: string) {
     const leftWidth = ((mid - min) / range) * 100;
     const rightWidth = ((max - mid) / range) * 100;
 
@@ -71,7 +100,17 @@ export default class extends Controller<HTMLElement> {
 
     this.minInputTarget.max = mid.toFixed(this.precisionValue);
     this.maxInputTarget.min = mid.toFixed(this.precisionValue);
+  }
 
+  protected updateGradients(
+    mid: number,
+    min: number,
+    max: number,
+    minValue: number,
+    maxValue: number,
+    thumbWidth: number,
+    thumbWidthUnit: string,
+  ) {
     const minFill = (minValue - min) / (mid - min) || 0;
     const maxFill = (maxValue - mid) / (max - mid) || 0;
 
@@ -86,8 +125,9 @@ export default class extends Controller<HTMLElement> {
       '--ux-search-range-slider-max-gradient-position',
       `calc(${(maxFill * 100).toFixed(this.precisionValue)}% + ${maxFillThumb}${thumbWidthUnit})`,
     );
+  }
 
-    // Update displayed values
+  protected updateDisplayedValues() {
     if (this.hasMinValueTarget) {
       this.minValueTarget.innerHTML = `${this.leadingValue}${this.minInputTarget.value}${this.trailingValue}`;
     }


### PR DESCRIPTION
Fix range slider display when min === max (single value)                                                         
                                                                                                                   
When filtering results to a single value, the range slider previously displayed incorrectly with both thumbs at the start position and an empty track.

Now displays a filled track with thumbs positioned at both extremities to properly indicate the single value state.

Additionally, `range-slider_controller.ts` has been refactored into specialized methods to improve maintainability and allow easier extension by bundle users.