### PR TITLE
Update phpdocumentor/reflection-docblock version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": ">=8.3",
     "nyholm/psr7": "^1.0",
-    "phpdocumentor/reflection-docblock": "^5.4",
+    "phpdocumentor/reflection-docblock": "^5.4|^6.0",
     "symfony/asset": "^6.4|^7.0|^8.0",
     "symfony/config": "^6.4|^7.0|^8.0",
     "symfony/dependency-injection": "^6.4|^7.0|^8.0",


### PR DESCRIPTION
Symfony has fixed the issue that blocked this upgrade.