### PR TITLE
Register maker command only when MakerBundle is installed

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -124,7 +124,12 @@ return static function (ContainerConfigurator $container) {
         ->set(DefaultUrlFormater::class)
             ->arg('$urlGenerator', service(UrlGeneratorInterface::class))
             ->tag('mezcalito_ux_search.url_formater')
-        ->set('maker.maker.make_search', MakeSearch::class)
-            ->tag('maker.command')
     ;
+
+    if (class_exists(\Symfony\Bundle\MakerBundle\Maker\AbstractMaker::class)) {
+        $container->services()
+            ->set('maker.maker.make_search', MakeSearch::class)
+                ->tag('maker.command')
+        ;
+    }
 };


### PR DESCRIPTION
Fixes #47.

## What changed

This guards registration of the `maker.maker.make_search` service so it is only added when `Symfony\Bundle\MakerBundle\Maker\AbstractMaker` is available.

## Why

`symfony/maker-bundle` is currently a dev dependency, but `config/services.php` always registers `Mezcalito\UxSearchBundle\Maker\MakeSearch`. That class extends MakerBundle `AbstractMaker`, so consuming applications without MakerBundle installed can trigger a fatal autoload error during container compilation.

The maker command remains available for development installs that include MakerBundle, while production installs can use the search bundle without requiring MakerBundle.

## Validation

- `php -l config/services.php`
- `composer validate --no-check-publish`
- Verified the consuming Symfony app can clear both dev and prod cache after avoiding the optional maker autoload path.