### PR TITLE
Dispatch search events on the global event dispatcher

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -52,6 +52,7 @@ return static function (ContainerConfigurator $container) {
         ->set(Searcher::class)
             ->arg('$adapterProvider', service(AdapterProvider::class))
             ->arg('$contextProvider', service(ContextProvider::class))
+            ->arg('$eventDispatcher', service('event_dispatcher'))
         ->set(QueryBuilder::class)
         ->set(ContextProvider::class)
         ->set(AdapterProvider::class)

--- a/src/Search/Searcher.php
+++ b/src/Search/Searcher.php
@@ -19,21 +19,28 @@ use Mezcalito\UxSearchBundle\Event\PostSearchEvent;
 use Mezcalito\UxSearchBundle\Event\PreSearchEvent;
 use Mezcalito\UxSearchBundle\EventSubscriber\ContextSubscriber;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 readonly class Searcher
 {
     public function __construct(
         private AdapterProvider $adapterProvider,
         private ContextProvider $contextProvider,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
     public function search(Query $query, SearchInterface $search): ResultSet\ResultSet
     {
-        $eventDispatcher = $search->getEventDispatcher();
+        $searchEventDispatcher = $search->getEventDispatcher();
         $search->addEventSubscriber(new ContextSubscriber($this->contextProvider));
 
-        $eventDispatcher->dispatch(new PreSearchEvent($query, $search));
+        // Dispatch on the search's own dispatcher (per-search subscribers, e.g.
+        // ContextSubscriber) and on the global dispatcher so application/bundle
+        // subscribers can hook search events the usual way.
+        $preEvent = new PreSearchEvent($query, $search);
+        $searchEventDispatcher->dispatch($preEvent);
+        $this->eventDispatcher->dispatch($preEvent);
 
         $adapter = $this->adapterProvider->getAdapter($search->getAdapterName());
 
@@ -43,7 +50,9 @@ readonly class Searcher
 
         $results = $adapter->search($query, $search);
 
-        $eventDispatcher->dispatch(new PostSearchEvent($query, $search, $results));
+        $postEvent = new PostSearchEvent($query, $search, $results);
+        $searchEventDispatcher->dispatch($postEvent);
+        $this->eventDispatcher->dispatch($postEvent);
 
         return $results;
     }

--- a/tests/Search/SearcherTest.php
+++ b/tests/Search/SearcherTest.php
@@ -96,7 +96,7 @@ class SearcherTest extends TestCase
 
         $search->method('getEventDispatcher')->willReturn($eventDispatcher);
 
-        $searcher = new Searcher($adapterProvider, $contextProvider);
+        $searcher = new Searcher($adapterProvider, $contextProvider, new EventDispatcher());
 
         $rs = $searcher->search($query, $search);
 


### PR DESCRIPTION
Currently `Searcher` dispatches `PreSearchEvent`/`PostSearchEvent` only on each searchs private `EventDispatcher`. The only subscriber wired to it is the internal `ContextSubscriber`, so application or bundle subscribers registered the normal `kernel.event_subscriber` way never receive search events.

This injects the framework event dispatcher and dispatches the events on it as well, while keeping the per-search dispatch for backwards compatibility. This makes it possible to, e.g., post-process a `ResultSet` after every search (in my case hydrating raw-array hits from a DBAL adapter into Doctrine entities) without having to subclass or manually attach a subscriber to every search.

Backwards compatible: existing per-search subscribers keep working; the change only adds an additional dispatch on the global dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)